### PR TITLE
Do not emit error status for no push_release_tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -294,7 +294,9 @@ push_release_tag:
 
 release_tag:
 	if [ -z "${PUSHED_RELEASE_TAG}" ]; then \
-		${CHANGES} docker-compose.yml && make push_release_tag; \
+		if ${CHANGES} docker-compose.yml; then \
+			make push_release_tag; \
+		fi; \
 	fi
 
 


### PR DESCRIPTION
# Description

When a release tag is not to be pushed, the Makefile target ended with a non-zero exit status. This caused the build to fail. If a release tag is not to be pushed, this is a no-op, not an error.

Fixes (no issue id against this).

# Checklist

- [ ] If a new feature is being added, I have added a corresponding post to ``docs/``.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the wiki where applicable.
