### PR TITLE
Explicitly return nil when key_pair is not found

### DIFF
--- a/hailstorm-gem/lib/hailstorm/support/aws_adapter_clients/key_pair_client.rb
+++ b/hailstorm-gem/lib/hailstorm/support/aws_adapter_clients/key_pair_client.rb
@@ -9,6 +9,7 @@ class Hailstorm::Support::AwsAdapter::KeyPairClient < Hailstorm::Support::AwsAda
     key_pair_info ? key_pair_info[:key_pair_id] : nil
   rescue Aws::EC2::Errors::ServiceError => service_error
     logger.warn(service_error.message)
+    nil
   end
 
   def delete(key_pair_id:)


### PR DESCRIPTION
# Description

Fixed an issue when finding a key_pair. There was a need for explicit ``nil`` return instead of leaving it to the last statement.

# Linked Issues

- #143 

# Checklist

- [x] If a new feature is being added, I have added a corresponding post to ``docs/``. (not a new feature)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have made corresponding changes to the wiki where applicable. (no change to wiki needed)
