### PR TITLE
Disable style/alias rubocop rule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -59,6 +59,9 @@ Style/MixinUsage:
 Style/AccessModifierDeclarations:
   Enabled: false
 
+Style/Alias:
+  Enabled: false
+
 Metrics/LineLength:
   Max: 120
 

--- a/hailstorm-gem/lib/hailstorm/support/ssh.rb
+++ b/hailstorm-gem/lib/hailstorm/support/ssh.rb
@@ -74,7 +74,7 @@ class Hailstorm::Support::SSH
   module ConnectionSessionInstanceMethods
     include Hailstorm::Behavior::SshConnection
 
-    alias net_ssh_exec exec
+    alias_method :net_ssh_exec, :exec
 
     #:nodoc:
     def exec(command, options = {}, &block)


### PR DESCRIPTION
# Description

The ``style/alias`` rule is disabled because it seems arbitrary. This rule created a false negative when overriding Net::SSH behavior.

# Linked Issues

- #144

# Checklist

- [x] If a new feature is being added, I have added a corresponding post to ``docs/``. (no new feature)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have made corresponding changes to the wiki where applicable. (no changes)
