### PR TITLE
Invoke existing instance method from module method.

### DIFF
--- a/hailstorm-gem/lib/hailstorm/behavior/ssh_connection.rb
+++ b/hailstorm-gem/lib/hailstorm/behavior/ssh_connection.rb
@@ -4,22 +4,24 @@ require 'hailstorm/behavior'
 module Hailstorm::Behavior::SshConnection
   attr_accessor :logger
 
+  # This is a stub. Used for indexing and helping verifying doubles to assert that this method exists
+  # while stubbing behavior.
   def net_ssh_exec(*)
     # :nocov:
     raise(NotImplementedError, "#{self.class}##{__method__} implementation not found.")
     # :nocov:
   end
 
+  # This is a stub. Used for indexing and helping verifying doubles to assert that this method exists
+  # while stubbing behavior.
   def exec(*)
-    # :nocov:
-    raise(NotImplementedError, "#{self.class}##{__method__} implementation not found.")
-    # :nocov:
+    super
   end
 
+  # This is a stub. Used for indexing and helping verifying doubles to assert that this method exists
+  # while stubbing behavior.
   def exec!(*)
-    # :nocov:
-    raise(NotImplementedError, "#{self.class}##{__method__} implementation not found.")
-    # :nocov:
+    super
   end
 
   # @param [String] _file_path full path to file on remote system


### PR DESCRIPTION
# Description

Methods already existing on a ``Net::SSH`` instance were overidden by module methods that threw a ``NotImplementedError``. Modified the module methods to call the ``Net::SSH`` methods instead.

# Linked Issues

- #144 

# Checklist

- [x] If a new feature is being added, I have added a corresponding post to ``docs/``. (no new feature)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have made corresponding changes to the wiki where applicable. (no change needed)
