### PR TITLE
Check gem spec instead of lock file to validate CLI version

### DIFF
--- a/hailstorm-cli/Makefile
+++ b/hailstorm-cli/Makefile
@@ -86,7 +86,7 @@ release_makefile:
 
 validate:
 	CLI_VERSION_CHANGED=0; \
-	for glob in bin lib templates Gemfile.lock; do \
+	for glob in bin lib templates hailstorm-cli.gemspec; do \
 		if ${TRAVIS_BUILD_DIR}/.travis/build-condition.sh ${TRAVIS_COMMIT_RANGE} hailstorm-cli/$$glob; then \
 			${TRAVIS_BUILD_DIR}/.travis/build-condition.sh ${TRAVIS_COMMIT_RANGE} hailstorm-cli/lib/hailstorm/cli/version.rb; \
 			CLI_VERSION_CHANGED=$$?; \


### PR DESCRIPTION
# Description

The lock file can change due to version updates to test and development groups. It should not increment the CLI version. The gem spec on the other hand is a better predictor of a version increment.

# Linked Issues

- #145 

# Checklist

- [x] No new feature / If a new feature is being added, I have added a corresponding post to ``docs/``.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] No changes needed / I have made corresponding changes to the wiki where applicable.
