### PR TITLE
Fix release version calculation

### DIFF
--- a/hailstorm-cli/Makefile
+++ b/hailstorm-cli/Makefile
@@ -94,3 +94,6 @@ validate:
 		fi; \
 	done; \
 	[ $$CLI_VERSION_CHANGED -eq 0 ]
+
+release_version:
+	@echo ${RELEASE_VERSION}


### PR DESCRIPTION
# Description

The calculation of the release version missed the CLI. This adds the CLI version number to that calculation.

# Linked Issues

- #145 

# Checklist

- [x] No new feature / If a new feature is being added, I have added a corresponding post to ``docs/``.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] No changes to wiki / I have made corresponding changes to the wiki where applicable.
