### PR TITLE
(fix) Reuse instance when threads within range

### DIFF
--- a/hailstorm-api/app/api/aws_ec2_pricing_options.rb
+++ b/hailstorm-api/app/api/aws_ec2_pricing_options.rb
@@ -25,10 +25,5 @@ get '/aws_ec2_pricing_options/:region_code' do |region_code|
   end
 
   prices_data = JSON.parse(raw_prices_data)
-  prices_with_max_threads = prices_data.map do |item|
-    max_threads = AMAZON_CLOUD_DEFAULTS.calc_max_threads_per_instance(instance_type: item['instanceType'])
-    item.merge(maxThreadsByInstance: max_threads, numInstances: 1)
-  end
-
-  JSON.dump(prices_with_max_threads.sort_by { |a| a['hourlyCostByInstance'] })
+  JSON.dump(prices_with_max_threads(prices_data).sort_by { |a| a['hourlyCostByInstance'] })
 end

--- a/hailstorm-api/app/helpers/aws_ec2_pricing_helper.rb
+++ b/hailstorm-api/app/helpers/aws_ec2_pricing_helper.rb
@@ -18,6 +18,17 @@ module AwsEc2PricingHelper
     JSON.dump(selected_item_attrs)
   end
 
+  # @param [Enumerable] prices_data
+  def prices_with_max_threads(prices_data)
+    prices_data
+      .select { |item| AMAZON_CLOUD_DEFAULTS.known_instance_type?(item['instanceType']) }
+      .map do |item|
+
+      max_threads = AMAZON_CLOUD_DEFAULTS.calc_max_threads_per_instance(instance_type: item['instanceType'])
+      item.merge(maxThreadsByInstance: max_threads, numInstances: 1)
+    end
+  end
+
   private
 
   def projection(item)

--- a/hailstorm-api/app/helpers/clusters_helper.rb
+++ b/hailstorm-api/app/helpers/clusters_helper.rb
@@ -48,15 +48,16 @@ module ClustersHelper
 
   # @param [Hailstorm::Support::Configuration::ClusterBase] cluster_config
   # @param [Hash] api_params
+  # @return [Hailstorm::Support::Configuration::AmazonCloud]
   def amazon_cloud_config(cluster_config, api_params)
     # @type [Hailstorm::Support::Configuration::AmazonCloud] amz
     amz = cluster_config
     amz.access_key = api_params[:accessKey]
     amz.secret_key = api_params[:secretKey]
-    amz.instance_type = api_params[:instanceType].presence
-    amz.max_threads_per_agent = api_params[:maxThreadsByInstance] if api_params[:maxThreadsByInstance]
-    amz.region = api_params[:region].presence
-    amz.vpc_subnet_id = api_params[:vpcSubnetId].presence
+    amz.instance_type = api_params[:instanceType] unless api_params[:instanceType].blank?
+    amz.max_threads_per_agent = api_params[:maxThreadsByInstance] unless api_params[:maxThreadsByInstance].blank?
+    amz.region = api_params[:region] unless api_params[:region].blank?
+    amz.vpc_subnet_id = api_params[:vpcSubnetId] unless api_params[:vpcSubnetId].blank?
     amz
   end
 

--- a/hailstorm-api/spec/helpers/clusters_helper_spec.rb
+++ b/hailstorm-api/spec/helpers/clusters_helper_spec.rb
@@ -67,4 +67,20 @@ describe ClustersHelper do
       expect(sorted).to eq([{}, {}, {}, { disabled: true }.stringify_keys, { disabled: true }.stringify_keys])
     end
   end
+
+  context '#amazon_cloud_config' do
+    it 'should not set blank values' do
+      amz = @cluster_api_sim.amazon_cloud_config(Hailstorm::Support::Configuration::AmazonCloud.new,
+                                                 { accessKey: 'A',
+                                                   secretKey: 'S',
+                                                   vpcSubnetId: '',
+                                                   maxThreadsByInstance: nil })
+      amz_attrs_keys = amz.instance_values.symbolize_keys.keys
+      expect(amz_attrs_keys).to include(:access_key, :access_key)
+      expect(amz_attrs_keys).to_not include(:instance_type)
+      expect(amz_attrs_keys).to_not include(:max_threads_per_agent)
+      expect(amz_attrs_keys).to_not include(:region)
+      expect(amz_attrs_keys).to_not include(:vpc_subnet_id)
+    end
+  end
 end

--- a/hailstorm-cli/features/amazon_cloud_load_generation.feature
+++ b/hailstorm-cli/features/amazon_cloud_load_generation.feature
@@ -37,6 +37,7 @@ Feature: Generate load from AWS
     Then 1 active load agent should exist
     And 0 Jmeter instances should be running
 
+  @smoke
   @end-to-end
   @aws
   Scenario: Start test for 20 threads
@@ -53,6 +54,7 @@ Feature: Generate load from AWS
     Then 1 active load agent should exist
     And 1 Jmeter instance should be running
 
+  @smoke
   @end-to-end
   @aws
   Scenario: Stop the test with 20 threads
@@ -60,6 +62,7 @@ Feature: Generate load from AWS
     Then 1 active load agent should exist
     And 0 Jmeter instances should be running
 
+  @smoke
   @end-to-end
   @aws
   Scenario: Start test for 30 threads
@@ -76,6 +79,7 @@ Feature: Generate load from AWS
     Then 2 active load agents should exist
     And 2 Jmeter instances should be running
 
+  @smoke
   @end-to-end
   @aws
   Scenario: Stop the test with 30 threads

--- a/hailstorm-gem/lib/hailstorm/model/helper/amazon_cloud_defaults.rb
+++ b/hailstorm-gem/lib/hailstorm/model/helper/amazon_cloud_defaults.rb
@@ -13,6 +13,7 @@ class Hailstorm::Model::Helper::AmazonCloudDefaults
   INSTANCE_TYPE       = 'm5a.large'
   INSTANCE_CLASS_SCALE_FACTOR = { t2: 2, t3: 2, t3a: 2, m4: 4, m5: 5,
                                   m5a: 6, m5ad: 7, m5d: 8, m5dn: 9, m5n: 10 }.freeze
+  KNOWN_INSTANCE_CLASSES = INSTANCE_CLASS_SCALE_FACTOR.keys.freeze
   INSTANCE_TYPE_SCALE_FACTOR = 2
   KNOWN_INSTANCE_TYPES = [:nano, :micro, :small, :medium, :large, :xlarge,
                           '2xlarge'.to_sym, '4xlarge'.to_sym, '8xlarge'.to_sym, '10xlarge'.to_sym, '12xlarge'.to_sym,
@@ -28,7 +29,7 @@ class Hailstorm::Model::Helper::AmazonCloudDefaults
   # @param [String] instance_type
   # @return [Integer]
   def self.calc_max_threads_per_instance(instance_type:)
-    iclass, itype = instance_type.split(/\./).collect(&:to_sym)
+    iclass, itype = parse_class_type(instance_type)
     iclass ||= :t3a
     itype ||= :small
     itype_index = KNOWN_INSTANCE_TYPES.find_index(itype).to_i - 2 # :small is 0th index, :nano is -2
@@ -44,5 +45,14 @@ class Hailstorm::Model::Helper::AmazonCloudDefaults
               computed <= 50 ? 10 : 50
             end
     (computed.to_f / pivot).round * pivot
+  end
+
+  def self.known_instance_type?(instance_type)
+    iclass, = parse_class_type(instance_type)
+    KNOWN_INSTANCE_CLASSES.include?(iclass)
+  end
+
+  def self.parse_class_type(instance_type)
+    instance_type.split(/\./).collect(&:to_sym)
   end
 end

--- a/hailstorm-gem/spec/model/helper/amazon_cloud_defaults_spec.rb
+++ b/hailstorm-gem/spec/model/helper/amazon_cloud_defaults_spec.rb
@@ -25,4 +25,10 @@ describe Hailstorm::Model::Helper::AmazonCloudDefaults do
       expect(described_class.max_threads_per_agent(375)).to eq(400)
     end
   end
+
+  it 'should validate if an instance type is supported' do
+    expect(described_class.known_instance_type?('t3ga.small')).to be false
+    expect(described_class.known_instance_type?('t3.small')).to be true
+    expect(described_class.known_instance_type?('t3.medium')).to be true
+  end
 end

--- a/hailstorm-web-client/e2e/features/amazon_cloud_load_generation.feature
+++ b/hailstorm-web-client/e2e/features/amazon_cloud_load_generation.feature
@@ -19,6 +19,7 @@ Feature: Generate load from AWS
     And finalize the configuration
     And start load generation
     Then 1 test should be running
+    And 1 load agent should exist
 
   @smoke
   @end-to-end
@@ -27,6 +28,7 @@ Feature: Generate load from AWS
     When I wait for load generation to stop
     Then 1 tests should exist
 
+  @smoke
   @end-to-end
   Scenario: Start test for 20 threads
     When I reconfigure the project
@@ -41,7 +43,9 @@ Feature: Generate load from AWS
     And finalize the configuration
     And start load generation
     Then 1 test should be running
+    And 1 load agent should exist
 
+  @smoke
   @end-to-end
   Scenario: Stop the test with 20 threads
     When I wait for load generation to stop
@@ -61,6 +65,7 @@ Feature: Generate load from AWS
     And finalize the configuration
     And start load generation
     Then 1 test should be running
+    And 2 load agents should exist
 
   @end-to-end
   Scenario: Stop the test with 30 threads

--- a/hailstorm-web-client/e2e/features/step-definitions/api.steps.ts
+++ b/hailstorm-web-client/e2e/features/step-definitions/api.steps.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import config from 'environment.e2e';
 import axios from 'axios';
 
-Then("{int} load agents should exist", async function(loadAgentCount) {
+Then("{int} load agent(s) should exist", async function(loadAgentCount) {
   const response = await axios.get(`${config.apiBaseURL}/projects/${this.projectId}/load_agents`);
   expect(response.status).to.equal(200);
   expect(response.data.length).to.equal(loadAgentCount);

--- a/hailstorm-web-client/e2e/features/step-definitions/browser.steps.ts
+++ b/hailstorm-web-client/e2e/features/step-definitions/browser.steps.ts
@@ -50,6 +50,7 @@ When("finalize the configuration", function() {
 
 When("start load generation", function() {
   projectWorkspace.startTest();
+  this.projectId = projectWorkspace.projectIdFromUrl();
 });
 
 Then("{int} test should be running", function(numRows) {
@@ -83,7 +84,8 @@ When("wait for tests to abort", function() {
 });
 
 When("I terminate the setup", function() {
-  this.projectId = projectWorkspace.terminateProject();
+  this.projectId = projectWorkspace.projectIdFromUrl();
+  projectWorkspace.terminateProject();
 });
 
 Given("some tests have completed", function() {

--- a/hailstorm-web-client/e2e/features/support/po.ts
+++ b/hailstorm-web-client/e2e/features/support/po.ts
@@ -224,7 +224,7 @@ class ProjectWorkspace {
     }, seconds * 1000);
   }
 
-  terminateProject(): string {
+  terminateProject() {
     this.showDangerousSettings.click();
     this.terminateButton.waitForDisplayed(1000);
     this.terminateButton.click();
@@ -232,7 +232,6 @@ class ProjectWorkspace {
     this.confirmTerminate.click();
     this.terminateButton.waitForEnabled(1000, true);
     browser.waitUntil(() => this.terminateButton.isEnabled(), 5 * 60 * 1000, "wait for terminate action to complete", 3000);
-    return path.basename((new URL(browser.getUrl())).hash.slice(1));
   }
 
   generateReport() {
@@ -244,6 +243,10 @@ class ProjectWorkspace {
   waitForGeneratedReports() {
     browser.waitUntil(() => this.reportsListItems.length > 0, 5 * 60 * 1000, "waiting for report to be generated", 10000);
     return this.reportsListItems.length;
+  }
+
+  projectIdFromUrl(): string {
+    return path.basename((new URL(browser.getUrl())).hash.slice(1));
   }
 }
 

--- a/hailstorm-web-client/e2e/wdio.smoke.conf.js
+++ b/hailstorm-web-client/e2e/wdio.smoke.conf.js
@@ -1,4 +1,5 @@
 const devConf = require('./wdio.conf');
 devConf.config.baseUrl = 'http://localhost:8080';
 devConf.config.cucumberOpts.tagExpression = '@smoke';
+devConf.config.cucumberOpts.failFast = true;
 exports.config = devConf.config;


### PR DESCRIPTION
# Description

From the web client, when number of threads was increased, the API would create a new instance even if the number of threads was less than maximum configured. This was because empty parameters were sent to the DB layer, which were converted to ``IS NULL`` checks. This would select no records, because the attribute in DB could have been assigned a default value. Perhaps there's a case for back propagating the default values in the project configuration, and can be explored in #132. 

# Linked Issues

- #95 

# Checklist

- [x] No new feature / If a new feature is being added, I have added a corresponding post to ``docs/``.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] No changes needed / I have made corresponding changes to the wiki where applicable.
