### PR TITLE
Modify trigger for manual AWS inputs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.2'
 services:
   web:
-    image: "hailstorm3/hailstorm-web-client:1.4.5"
+    image: "hailstorm3/hailstorm-web-client:1.4.6"
     ports:
       - "8080:80"
     networks:

--- a/hailstorm-web-client/package.json
+++ b/hailstorm-web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hailstorm-web-client",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "private": true,
   "dependencies": {
     "date-fns": "^2.6.0",

--- a/hailstorm-web-client/src/ClusterConfiguration/AWSInstanceChoice.test.tsx
+++ b/hailstorm-web-client/src/ClusterConfiguration/AWSInstanceChoice.test.tsx
@@ -68,9 +68,9 @@ describe('<AWSInstanceChoice />', () => {
     );
 
     await fetchPricing;
-    const switchLink = await findByText(/advanced mode/i);
+    const switchLink = await findByText(/specify yourself/i);
     fireEvent.click(switchLink);
-    await findByText(/quick mode/i);
+    await findByText(/specify yourself/i);
     await findByTestId('AWS Instance Type');
     await findByTestId('Max. Users / Instance');
   });
@@ -82,7 +82,7 @@ describe('<AWSInstanceChoice />', () => {
       );
 
       await fetchPricing;
-      const switchLink = await findByText(/advanced mode/i);
+      const switchLink = await findByText(/specify yourself/i);
       fireEvent.click(switchLink);
       const awsInstanceType = await findByTestId('AWS Instance Type');
       const maxThreadsPerInstance = await findByTestId('Max. Users / Instance');
@@ -109,14 +109,14 @@ describe('<AWSInstanceChoice />', () => {
       );
 
       await fetchPricing;
-      let switchLink = await findByText(/advanced mode/i);
+      let switchLink = await findByText(/specify yourself/i);
       fireEvent.click(switchLink);
       let awsInstanceType = await findByTestId('AWS Instance Type');
       let maxThreadsPerInstance = await findByTestId('Max. Users / Instance');
       fireEvent.change(awsInstanceType, {target: {value: 't2.small'}});
       fireEvent.change(maxThreadsPerInstance, {target: {value: '25'}});
 
-      switchLink = await findByText(/quick mode/i);
+      switchLink = await findByText(/determine by usage/i);
       fireEvent.click(switchLink);
       awsInstanceType = await findByTestId('AWS Instance Type');
       maxThreadsPerInstance = await findByTestId('Max. Users / Instance');
@@ -136,7 +136,7 @@ describe('<AWSInstanceChoice />', () => {
       );
 
       await fetchPricing;
-      const switchLink = await findByText(/advanced mode/i);
+      const switchLink = await findByText(/specify yourself/i);
       fireEvent.click(switchLink);
       expect(setHourlyCostByCluster).toBeCalledWith(undefined);
     });

--- a/hailstorm-web-client/src/ClusterConfiguration/AWSInstanceChoice.tsx
+++ b/hailstorm-web-client/src/ClusterConfiguration/AWSInstanceChoice.tsx
@@ -56,101 +56,162 @@ export function AWSInstanceChoice({
   return (
     <div className="card">
       <div className="card-header">
-        <p className="card-header-title">
-          AWS Instance{quickMode ? ' Advisor': ''}
-        </p>
-        {!disabled && (<a
-          className="card-header-icon is-size-7"
-          onClick={() => {
-            if (quickMode) {
-              setHourlyCostByCluster && setHourlyCostByCluster(undefined);
-            } else {
-              handleSliderChange(MIN_VALUE);
-            }
-
-            setQuickMode(!quickMode);
-          }}
-        >
-          {quickMode ? 'Advanced ' : 'Quick '}Mode
-        </a>)}
+        <p className="card-header-title">AWS Instance</p>
       </div>
       <div className="card-content">
         {quickMode ? (
-        <>
-        <div className="field">
-          <div className="control">
-            <NonLinearSlider
-              initialValue={MIN_VALUE}
-              onChange={handleSliderChange}
-              step={50}
-              maximum={maxThreadsByCluster(pricingData)}
-              minimum={MIN_VALUE}
-              {...{disabled}}
-            />
+          <div className="level">
+            <CenteredLevelItem title="AWS Instance Type" starred={true}>
+              {instanceType}
+            </CenteredLevelItem>
+            <CenteredLevelItem title="Max. Users / Instance" starred={true}>
+              {maxThreadsByInstance}
+            </CenteredLevelItem>
+            <CenteredLevelItem title="# Instances">
+              {numInstances}
+            </CenteredLevelItem>
           </div>
-        </div>
-        <hr/>
-        <div className="level">
-          <CenteredLevelItem title="AWS Instance Type" starred={true}>
-            {instanceType}
-          </CenteredLevelItem>
-          <CenteredLevelItem title="Max. Users / Instance" starred={true}>
-            {maxThreadsByInstance}
-          </CenteredLevelItem>
-          <CenteredLevelItem title="# Instances">
-            {numInstances}
-          </CenteredLevelItem>
-        </div>
-        </>
-        ) : (
-        <>
-        <div className="field">
-          <label className="label">AWS Instance Type *</label>
-          <div className="control">
-            <input
-              required
-              type="text"
-              className="input"
-              name="awsInstanceType"
-              data-testid="AWS Instance Type"
-              value={instanceType}
-              onChange={(event: {target: {value: string}}) => {
-                setInstanceType(event.target.value);
-                onChange(new AWSInstanceChoiceOption({
-                  instanceType: event.target.value,
-                  maxThreadsByInstance
-                }));
-              }}
-              {...{disabled}}
-            />
+      ) : (
+          <CustomInputSection
+            {...{
+              instanceType,
+              setInstanceType,
+              onChange,
+              maxThreadsByInstance,
+              setMaxThreadsByInstance,
+              disabled,
+            }}
+          />
+        )}
+        {!disabled && (
+          <SwitchMessage
+            {...{
+              quickMode,
+              setQuickMode,
+              setHourlyCostByCluster,
+              handleSliderChange,
+            }}
+          />
+        )}
+        {quickMode && (
+          <div className="field">
+            <div className="control">
+              <NonLinearSlider
+                initialValue={MIN_VALUE}
+                onChange={handleSliderChange}
+                step={50}
+                maximum={maxThreadsByCluster(pricingData)}
+                minimum={MIN_VALUE}
+                {...{ disabled }}
+              />
+            </div>
           </div>
-        </div>
-        <div className="field">
-          <label className="label">Max. Users / Instance *</label>
-          <div className="control">
-            <input
-              required
-              type="text"
-              className="input"
-              name="maxThreadsByInstance"
-              data-testid="Max. Users / Instance"
-              value={maxThreadsByInstance}
-              onChange={(event: {target: {value: string}}) => {
-                setMaxThreadsByInstance(parseInt(event.target.value));
-                onChange(new AWSInstanceChoiceOption({
-                  maxThreadsByInstance: parseInt(event.target.value),
-                  instanceType
-                }));
-              }}
-              {...{disabled}}
-            />
-          </div>
-        </div>
-        </>
         )}
       </div>
     </div>
-  )
+  );
+}
+
+function CustomInputSection({
+  instanceType,
+  setInstanceType,
+  onChange,
+  maxThreadsByInstance,
+  setMaxThreadsByInstance,
+  disabled
+}: {
+  instanceType: string;
+  setInstanceType: React.Dispatch<React.SetStateAction<string>>;
+  onChange: (choice: AWSInstanceChoiceOption) => void,
+  maxThreadsByInstance: number,
+  disabled: boolean | undefined,
+  setMaxThreadsByInstance: React.Dispatch<React.SetStateAction<number>>
+}): JSX.Element {
+  return (
+    <>
+      <div className="field">
+        <label className="label">AWS Instance Type *</label>
+        <div className="control">
+          <input
+            required
+            type="text"
+            className="input"
+            name="awsInstanceType"
+            data-testid="AWS Instance Type"
+            value={instanceType}
+            onChange={(event: { target: { value: string; }; }) => {
+              setInstanceType(event.target.value);
+              onChange(new AWSInstanceChoiceOption({
+                instanceType: event.target.value,
+                maxThreadsByInstance
+              }));
+            } }
+            {...{ disabled }} />
+        </div>
+      </div>
+      <div className="field">
+        <label className="label">Max. Users / Instance *</label>
+        <div className="control">
+          <input
+            required
+            type="text"
+            className="input"
+            name="maxThreadsByInstance"
+            data-testid="Max. Users / Instance"
+            value={maxThreadsByInstance}
+            onChange={(event: { target: { value: string; }; }) => {
+              setMaxThreadsByInstance(parseInt(event.target.value));
+              onChange(new AWSInstanceChoiceOption({
+                maxThreadsByInstance: parseInt(event.target.value),
+                instanceType
+              }));
+            } }
+            {...{ disabled }} />
+        </div>
+      </div>
+      <div className="field">
+        <label className="label"># Instances</label>
+        <div className="control">
+          <input className="input" type="text" placeholder="Calculated automatically" disabled />
+        </div>
+      </div>
+    </>
+  );
+}
+
+function SwitchMessage({
+  quickMode,
+  setHourlyCostByCluster,
+  handleSliderChange,
+  setQuickMode
+}: {
+  quickMode: boolean;
+  setHourlyCostByCluster: React.Dispatch<React.SetStateAction<number | undefined>> | undefined;
+  handleSliderChange: (value: number, data?: AWSInstanceChoiceOption[] | undefined) => AWSInstanceChoiceOption;
+  setQuickMode: React.Dispatch<React.SetStateAction<boolean>>
+}): JSX.Element {
+
+  const labelText = quickMode ? 'Determine by usage' : 'Specify yourself';
+  const link = (<a
+    className="has-text-link"
+    onClick={() => {
+      if (quickMode) {
+        setHourlyCostByCluster && setHourlyCostByCluster(undefined);
+      } else {
+        handleSliderChange(MIN_VALUE);
+      }
+
+      setQuickMode(!quickMode);
+    } }
+  >
+    {quickMode ? 'Specify yourself' : 'Determine by usage'}
+  </a>);
+
+  return (
+  <div className="notification is-size-7">
+    {labelText} or {link}
+  </div>
+  );
 }
 
 function CenteredLevelItem({


### PR DESCRIPTION
# Description

Modified the location of the link to display the inputs to set custom AWS instance type and number of threads (virtual users) per instance.

# Linked Issues

- #198 

# Checklist

- [x] No new feature / If a new feature is being added, I have added a corresponding post to ``docs/``.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have made corresponding changes to the wiki where applicable.
