### PR TITLE
Set env var without ::set-env

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,13 +14,13 @@ jobs:
         uses: actions/checkout@master
       - name: Get release version
         run: |
-          echo "::set-env name=release_version::$(basename ${{ github.ref }})"
+          echo "release_version=$(basename ${{ github.ref }})" >> $GITHUB_ENV
       - name: Build package
         run: |
           ./.github/workflows/build.sh ${{ env.release_version }}
       - name: Get commit message
         run: |
-          echo "::set-env name=commit_message::$(git log --format=%B -n 1 ${{ github.sha }})"
+          echo "commit_message=$(git log --format=%B -n 1 ${{ github.sha }})" >> $GITHUB_ENV
       - name: Create release
         id: create_release
         uses: actions/create-release@latest


### PR DESCRIPTION
# Description

GitHub Actions has deprecated set-env. Using the recommended approach instead. 

# Linked Issues

- none

# Checklist

- [x] If a new feature is being added, I have added a corresponding post to ``docs/``.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have made corresponding changes to the wiki where applicable.
