### PR TITLE
Match web client version in Docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.2'
 services:
   web:
-    image: "hailstorm3/hailstorm-web-client:1.5.7"
+    image: "hailstorm3/hailstorm-web-client:1.5.8"
     ports:
       - "8080:80"
     networks:


### PR DESCRIPTION
# Description

The web client version was updated in ``package.json`` but not in ``docker-compose.yml``. Updating the version in the docker compose file is necessary for a new release.

# Linked Issues

- None

# Checklist

- [x] If a new feature is being added, I have added a corresponding post to ``docs/``.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have made corresponding changes to the wiki where applicable.
