### PR TITLE
Show indicator when updating AWS price

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.2'
 services:
   web:
-    image: "hailstorm3/hailstorm-web-client:1.7.9"
+    image: "hailstorm3/hailstorm-web-client:1.7.10"
     ports:
       - "8080:80"
     networks:

--- a/hailstorm-web-client/package-lock.json
+++ b/hailstorm-web-client/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hailstorm-web-client",
-  "version": "1.7.9",
+  "version": "1.7.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hailstorm-web-client/package.json
+++ b/hailstorm-web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hailstorm-web-client",
-  "version": "1.7.9",
+  "version": "1.7.10",
   "private": true,
   "dependencies": {
     "date-fns": "^2.6.0",

--- a/hailstorm-web-client/src/ClusterConfiguration/AWSInstanceChoice.test.tsx
+++ b/hailstorm-web-client/src/ClusterConfiguration/AWSInstanceChoice.test.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { render, mount } from 'enzyme';
-import { AWSInstanceChoice } from './AWSInstanceChoice';
+import { AWSInstanceChoice, InstanceTypeMeter } from './AWSInstanceChoice';
 import { AWSInstanceChoiceOption } from './domain';
 import { render as renderComponent, fireEvent } from '@testing-library/react';
 import { Form, Formik } from 'formik';
-import { AppNotificationProviderWithProps } from '../AppNotificationProvider/AppNotificationProvider';
+import { AppNotificationProviderWithProps } from '../AppNotificationProvider';
 
 jest.mock('./NonLinearSlider', () => ({
   __esModule: true,
@@ -243,5 +243,18 @@ describe('<AWSInstanceChoice />', () => {
     const presetValue = maxThreadsByInst.getAttribute('value');
     fireEvent.change(maxThreadsByInst, {target: {value: ''}});
     expect(maxThreadsByInst.getAttribute('value')).toEqual(presetValue);
+  });
+
+  it('show an indicator before price update', async () => {
+    const component = mount(
+      <InstanceTypeMeter
+        instanceType="m1.small"
+        numInstances={2}
+      />
+    );
+
+    expect(component).toContainExactlyOneMatchingElement('LoadingMessage');
+    component.setProps({hourlyCostByCluster: 0.12});
+    expect(component).not.toContain('LoadingMessage');
   });
 });

--- a/hailstorm-web-client/src/ClusterConfiguration/AWSInstanceChoice.tsx
+++ b/hailstorm-web-client/src/ClusterConfiguration/AWSInstanceChoice.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { NonLinearSlider } from './NonLinearSlider';
 import { computeChoice, maxThreadsByCluster } from './AWSInstanceCalculator';
 import { AWSInstanceChoiceOption } from './domain';
-import { Loader } from '../Loader/Loader';
+import { Loader, LoadingMessage } from '../Loader';
 import { Field } from 'formik';
 import { useNotifications } from '../app-notifications';
 
@@ -46,6 +46,7 @@ export function AWSInstanceChoice({
     console.debug('AWSInstanceChoice#useEffect(regionCode)');
     if (!quickMode) return;
 
+    setHourlyCostByCluster && setHourlyCostByCluster(undefined);
     fetchPricing(regionCode)
       .then((data) => {
         setPricingData(data);
@@ -253,7 +254,7 @@ function InstanceTypeInput({
   )
 }
 
-function InstanceTypeMeter({
+export function InstanceTypeMeter({
   instanceType,
   numInstances,
   hourlyCostByCluster
@@ -270,9 +271,15 @@ function InstanceTypeMeter({
       <CenteredLevelItem title="# Instances">
         {numInstances}
       </CenteredLevelItem>
-      {hourlyCostByCluster && (<CenteredLevelItem title="Hourly Cluster Cost" starred={true}>
-        ${hourlyCostByCluster.toFixed(4)}
-      </CenteredLevelItem>)}
+      {hourlyCostByCluster ? (
+        <CenteredLevelItem title="Hourly Cluster Cost" starred={true}>
+          ${hourlyCostByCluster.toFixed(4)}
+        </CenteredLevelItem>
+      ):(
+        <CenteredLevelItem title="Hourly Cluster Cost" starred={true}>
+          <LoadingMessage />
+        </CenteredLevelItem>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
# Description

On changing AWS region, an indicator is displayed when the new price is being fetched from AWS.

# Linked Issues

- fixes #105 

# Checklist

- [x] If a new feature is being added, I have added a corresponding post to ``docs/``.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have made corresponding changes to the wiki where applicable.
