### PR TITLE
'Disable' not 'Remove'  test plans with data #132

### DIFF
--- a/hailstorm-api/app/api/jmeter_plans.rb
+++ b/hailstorm-api/app/api/jmeter_plans.rb
@@ -15,17 +15,20 @@ get '/projects/:project_id/jmeter_plans' do |project_id|
 
   # @type [Hailstorm::Support::Configuration]
   hailstorm_config = deep_decode(project_config.stringified_config)
-  test_plans_attrs = (hailstorm_config.jmeter.test_plans || []).map { |e| { test_plan_name: e, jmx_file: true } }
+  test_plans_attrs = hailstorm_config.jmeter.all_test_plans_attrs
   data_files_attrs = (hailstorm_config.jmeter.data_files || []).map { |e| { test_plan_name: e, jmx_file: false } }
   files_attrs = test_plans_attrs + data_files_attrs
-  data_attrs = files_attrs.map { |partial_attrs| to_jmeter_attributes(hailstorm_config, project_id, partial_attrs) }
+  data_attrs = files_attrs.map do |partial_attrs|
+    deep_camelize_keys(to_jmeter_attributes(hailstorm_config, project_id, partial_attrs))
+  end
+
   JSON.dump(data_attrs)
 end
 
 post '/projects/:project_id/jmeter_plans' do |project_id|
   found_project = Hailstorm::Model::Project.find(project_id)
   request.body.rewind
-  jmeter_plan = configure_jmeter(found_project, request)
+  jmeter_plan = deep_camelize_keys(configure_jmeter(found_project, request))
   JSON.dump(jmeter_plan)
 end
 
@@ -40,16 +43,14 @@ patch '/projects/:project_id/jmeter_plans/:id' do |project_id, id|
   test_plan_name = hailstorm_config.jmeter.test_plans.find { |e| e.to_java_string.hash_code == id.to_i }
   return not_found unless test_plan_name
 
-  hailstorm_config.jmeter.properties(test_plan: test_plan_name) { |map| update_map(map, data) }
-  project_config.update!(stringified_config: deep_encode(hailstorm_config))
+  hailstorm_config
+    .jmeter
+    .properties(test_plan: test_plan_name) { |map| update_map(map, data) } unless data['properties'].blank?
 
-  path, name = test_plan_name.split('/')
-  JSON.dump(
-    id: test_plan_name.to_java_string.hash_code,
-    name: "#{name}.jmx",
-    path: path,
-    properties: hailstorm_config.jmeter.properties(test_plan: test_plan_name).entries
-  )
+  handle_disabled(data, hailstorm_config, test_plan_name)
+  project_config.update!(stringified_config: deep_encode(hailstorm_config))
+  resp = deep_camelize_keys(build_patch_response(hailstorm_config, test_plan_name, project_id))
+  JSON.dump(resp)
 end
 
 delete '/projects/:project_id/jmeter_plans/:id' do |project_id, id|
@@ -58,8 +59,13 @@ delete '/projects/:project_id/jmeter_plans/:id' do |project_id, id|
 
   hailstorm_config = deep_decode(project_config.stringified_config)
   test_plan_name = hailstorm_config.jmeter.test_plans.find { |e| e.to_java_string.hash_code == id.to_i }
-  hailstorm_config.jmeter.test_plans.reject! { |e| e == test_plan_name } if test_plan_name
-  if hailstorm_config.jmeter.data_files
+  if test_plan_name
+    return 402 if client_stats?(project_id, File.basename(test_plan_name))
+
+    hailstorm_config.jmeter.test_plans.reject! { |e| e == test_plan_name }
+  end
+
+  unless hailstorm_config.jmeter.data_files.blank?
     data_file_name = hailstorm_config.jmeter.data_files.find { |e| e.to_java_string.hash_code == id.to_i }
     hailstorm_config.jmeter.data_files.reject! { |e| e == data_file_name } if data_file_name
   end

--- a/hailstorm-api/app/helpers/api_helper.rb
+++ b/hailstorm-api/app/helpers/api_helper.rb
@@ -15,7 +15,7 @@ module ApiHelper
     Base64.encode64(Marshal.dump(obj))
   end
 
-  # @param [Sting] serz
+  # @param [String] serz
   # @return [Object]
   def deep_decode(serz)
     Marshal.load(Base64.decode64(serz)) # rubocop:disable Security/MarshalLoad

--- a/hailstorm-api/app/helpers/projects_helper.rb
+++ b/hailstorm-api/app/helpers/projects_helper.rb
@@ -79,7 +79,7 @@ module ProjectsHelper
     project_config = ProjectConfiguration.where(project_id: project.id).first
     if project_config
       hailstorm_config = deep_decode(project_config.stringified_config)
-      if hailstorm_config.jmeter.test_plans.empty? ||
+      if hailstorm_config.jmeter.enabled_test_plans.empty? ||
          hailstorm_config.clusters.select { |e| e.active || e.active.nil? }.empty?
         project_attrs[:incomplete] = true
       end

--- a/hailstorm-api/app/initializer/api_config.rb
+++ b/hailstorm-api/app/initializer/api_config.rb
@@ -8,6 +8,7 @@ require 'initializer/logger_redis_ext' unless Hailstorm.env == :test
 require 'hailstorm/initializer/java_classpath'
 require 'initializer/db_config'
 require 'initializer/migrations'
+require 'initializer/configuration_ext'
 require 'web_file_store'
 require 'version'
 

--- a/hailstorm-api/app/initializer/configuration_ext.rb
+++ b/hailstorm-api/app/initializer/configuration_ext.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'hailstorm/support/configuration'
+
+class Hailstorm::Support::Configuration
+  # JMeter extension
+  class JMeter
+
+    def disabled_test_plans
+      # For backward compatibility. Existing marshalled representations do not have this field, and unmarshalling
+      # does not invoke the constructor.
+      @disabled_test_plans ||= []
+    end
+
+    attr_writer :disabled_test_plans
+
+    alias original_initialize initialize
+    def initialize
+      original_initialize
+      self.disabled_test_plans = []
+    end
+
+    # @return [Array<Hash>] hash hash.keys = [:test_plan_name, :jmx_file, :disabled]
+    #                            test_plan_name: String
+    #                            jmx_file: Boolean, true
+    #                            disabled: Boolean
+    def all_test_plans_attrs
+      return [] if self.test_plans.nil?
+
+      self.test_plans.map do |plan|
+        attrs = { test_plan_name: plan, jmx_file: true }
+        attrs[:disabled] = true if self.disabled_test_plans.include?(plan)
+        attrs
+      end
+    end
+
+    # All test plans that are not disabled. Does not include data files
+    # @return [Array<String>]
+    def enabled_test_plans
+      self.test_plans.reject { |plan| self.disabled_test_plans.include?(plan) }
+    end
+  end
+end

--- a/hailstorm-api/spec/helpers/projects_helper_spec.rb
+++ b/hailstorm-api/spec/helpers/projects_helper_spec.rb
@@ -90,5 +90,24 @@ describe ProjectsHelper do
         expect(attrs).to_not include(:live)
       end
     end
+
+    context 'when all JMeter test plans are disabled' do
+      it 'should add incomplete attribute' do
+        config = Hailstorm::Support::Configuration.new
+        config.jmeter.add_test_plan('123/a.jmx')
+        config.jmeter.disabled_test_plans.push('123/a')
+        config.jmeter.data_files.push('135/b.csv')
+        config.clusters(:amazon_cloud) do |amz|
+          amz.access_key = 'a'
+          amz.secret_key = 'x'
+          amz.region = 'us-east-1'
+        end
+
+        ProjectConfiguration.create!(project: @project, stringified_config: deep_encode(config))
+        attrs = @api_instance.project_attributes(@project)
+        expect(attrs).to include(:incomplete)
+        expect(attrs[:incomplete]).to be == true
+      end
+    end
   end
 end

--- a/hailstorm-web-client/README.md
+++ b/hailstorm-web-client/README.md
@@ -84,7 +84,6 @@ This section has moved here: https://facebook.github.io/create-react-app/docs/tr
 ## Principles
 
 - Use flat source structure as much as possible.
-- Components with contained components become top level in source hierarchy even if they are not top level components in the DOM hierarchy.
 - Main component is responsible for connecting with global state & reducer. They get passed on as props to contained components.
 - Use CSS Modules for component CSS customizations, and SCSS for global styles.
-- Write new tests with Enzyme, but if they are flaky, change to react-test-utils. A test can be considered flaky if the test fails when an implementation detail changes, or they are timing dependent.
+- Write new tests with [React Testing Library](https://testing-library.com/docs/react-testing-library/intro/). If existing Enyzme tests are flaky, change to React Testing Library. A test can be considered flaky if the test fails when an implementation detail changes, or they are timing dependent.

--- a/hailstorm-web-client/src/ClusterConfiguration/AWSView.tsx
+++ b/hailstorm-web-client/src/ClusterConfiguration/AWSView.tsx
@@ -1,7 +1,7 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { Project, AmazonCluster } from '../domain';
 import { RemoveCluster } from './RemoveCluster';
-import styles from './ClusterConfiguration.module.scss';
+import styles from '../NewProjectWizard/NewProjectWizard.module.scss';
 import { ReadOnlyField } from './ReadOnlyField';
 import { ClusterViewHeader } from './ClusterViewHeader';
 import { MaxUsersByInstance } from './AWSInstanceChoice';

--- a/hailstorm-web-client/src/ClusterConfiguration/ClusterConfiguration.module.scss
+++ b/hailstorm-web-client/src/ClusterConfiguration/ClusterConfiguration.module.scss
@@ -12,11 +12,3 @@
     }
   }
 }
-
-.disabledContent {
-  background-color: $white-ter;
-}
-
-.titleLabel {
-  margin-left: 1rem;
-}

--- a/hailstorm-web-client/src/ClusterConfiguration/DataCenterView.tsx
+++ b/hailstorm-web-client/src/ClusterConfiguration/DataCenterView.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { DataCenterCluster, Project } from '../domain';
 import { RemoveCluster } from './RemoveCluster';
-import styles from './ClusterConfiguration.module.scss';
+import styles from '../NewProjectWizard/NewProjectWizard.module.scss';
 import { ReadOnlyField } from './ReadOnlyField';
 import { ClusterViewHeader } from './ClusterViewHeader';
 

--- a/hailstorm-web-client/src/ClusterList/ClusterList.test.tsx
+++ b/hailstorm-web-client/src/ClusterList/ClusterList.test.tsx
@@ -47,22 +47,6 @@ describe('<ClusterList />', () => {
     expect(wrapper.find('.button')).toBeDisabled();
   });
 
-  it('should display active cluster on top of list', async () => {
-    const {findAllByText, debug} = render(
-      <ClusterList
-        clusters={[
-          {id: 1, type: 'AWS', title: 'AWS us-east-1', code: 'aws-1' },
-          {id: 2, type: 'AWS', title: 'AWS us-west-1', code: 'aws-2' },
-        ]}
-        activeCluster={{id: 2, type: 'AWS', title: 'AWS us-west-1', code: 'aws-2' }}
-      />
-    );
-
-    const clusters = await findAllByText(/AWS us\-/);
-    expect(clusters[0].textContent).toMatch(/AWS us-west-1/);
-    expect(clusters[1].textContent).toMatch(/AWS us-east-1/);
-  });
-
   it('should display disabled clusters at bottom', async () => {
     const {findAllByText, debug} = render(
       <ClusterList

--- a/hailstorm-web-client/src/ClusterList/ClusterList.tsx
+++ b/hailstorm-web-client/src/ClusterList/ClusterList.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Cluster } from '../domain';
-import styles from '../ClusterConfiguration/ClusterConfiguration.module.scss';
+import styles from '../NewProjectWizard/NewProjectWizard.module.scss';
 import { EmptyPanel } from '../EmptyPanel';
 
 export const ClusterList: React.FC<{
@@ -14,10 +14,6 @@ export const ClusterList: React.FC<{
 }> = ({clusters, showEdit, onSelectCluster, activeCluster, disableEdit, onEdit, showDisabledCluster}) => {
 
   const sortFn: (a: Cluster, b: Cluster) => number = (a, b) => {
-    if (activeCluster && activeCluster.id === b.id) {
-      return 1;
-    }
-
     if (a.disabled) {
       return 1;
     }

--- a/hailstorm-web-client/src/JMeterConfiguration/ActiveFileDetail.tsx
+++ b/hailstorm-web-client/src/JMeterConfiguration/ActiveFileDetail.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import { NewProjectWizardState } from "../NewProjectWizard/domain";
-import { MergeJMeterFileAction } from './actions';
+import { DisableJMeterFileAction, EnableJMeterFileAction, MergeJMeterFileAction } from './actions';
 import { ApiFactory } from '../api';
 import { JMeterFileMessage } from './JMeterFileMessage';
-import { FormikActions } from 'formik';
 import { JMeterFileDetail } from './JMeterFileDetail';
 import { FormikActionsHandler } from './domain';
 import { useNotifications } from '../app-notifications';
@@ -45,6 +44,27 @@ export function ActiveFileDetail({ state, dispatch, setShowModal, setUploadAbort
       .then(() => setSubmitting(false));
   };
 
+  const toggleDisabled = (disabled: boolean) => {
+    if (state.wizardState && state.wizardState.activeJMeterFile && state.wizardState.activeJMeterFile.id) {
+      ApiFactory()
+        .jmeter()
+        .update(
+          state.activeProject!.id,
+          state.wizardState.activeJMeterFile.id,
+          {disabled}
+        )
+        .then(() => {
+          if (disabled) {
+            dispatch(new DisableJMeterFileAction(state.wizardState!.activeJMeterFile!.id!));
+            notifiers.notifyWarning(`JMeter plan "${state.wizardState!.activeJMeterFile!.name}" disabled`);
+          } else {
+            dispatch(new EnableJMeterFileAction(state.wizardState!.activeJMeterFile!.id!));
+            notifiers.notifySuccess(`JMeter plan "${state.wizardState!.activeJMeterFile!.name}" enabled`);
+          }
+        });
+    }
+  }
+
   return (
     <>
     {!state.wizardState!.activeJMeterFile && (
@@ -57,7 +77,7 @@ export function ActiveFileDetail({ state, dispatch, setShowModal, setUploadAbort
 
     {state.wizardState!.activeJMeterFile &&
     <JMeterFileDetail
-      {...{setShowModal, onSubmit}}
+      {...{setShowModal, onSubmit, toggleDisabled}}
       jmeterFile={state.wizardState!.activeJMeterFile}
     />}
     </>

--- a/hailstorm-web-client/src/JMeterConfiguration/JMeterConfiguration.tsx
+++ b/hailstorm-web-client/src/JMeterConfiguration/JMeterConfiguration.tsx
@@ -71,7 +71,7 @@ export const JMeterConfiguration: React.FC = () => {
 export function isNextDisabled(state: NewProjectWizardState): boolean {
   return (
     !state.activeProject!.jmeter ||
-    state.activeProject!.jmeter.files.filter(value => !value.dataFile).length === 0 ||
+    state.activeProject!.jmeter.files.filter(value => !value.dataFile && !value.disabled).length === 0 ||
     isBackDisabled(state)
   );
 }
@@ -107,14 +107,21 @@ async function destroyFile({
   dispatch: React.Dispatch<any>;
   notifiers: AppNotificationContextProps;
 }) {
+  let removeFile = true;
+
   if (file.id) {
     try {
       await ApiFactory().jmeter().destroy(projectId, file.id);
-      notifiers.notifySuccess(`Deleted the JMeter configuration`);
+      notifiers.notifySuccess(`Removed the ${file.dataFile ? 'data file' : 'JMeter plan'} from configuration`);
     }
     catch (reason) {
+      removeFile = false;
       notifiers.notifyError("Failed to remove JMeter from configuration", reason);
     }
+  }
+
+  if (!removeFile) {
+    return;
   }
 
   try {

--- a/hailstorm-web-client/src/JMeterConfiguration/JMeterFileDetail.tsx
+++ b/hailstorm-web-client/src/JMeterConfiguration/JMeterFileDetail.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { JMeterFile } from '../domain';
-import { FormikActions } from 'formik';
 import { JMeterPropertiesMap } from './JMeterPropertiesMap';
 import { JMeterFileUploadState } from '../NewProjectWizard/domain';
 import { isUploadInProgress } from './isUploadInProgress';
@@ -10,22 +9,27 @@ export function JMeterFileDetail({
   setShowModal,
   jmeterFile,
   onSubmit,
-  headerTitle
+  headerTitle,
+  toggleDisabled
 }: {
   setShowModal?: React.Dispatch<React.SetStateAction<boolean>>;
   jmeterFile: JMeterFile;
   onSubmit?: FormikActionsHandler;
   headerTitle?: string;
+  toggleDisabled?: (disabled: boolean) => void;
 }) {
-
   return (
     <>
     {mayShowProperties(jmeterFile) && (
     <JMeterPropertiesMap
       headerTitle={headerTitle || `Set properties for ${jmeterFile!.name}`}
-      properties={jmeterFile!.properties!}
+      properties={Array.from(jmeterFile!.properties!).map((value) => ({key: value[0], value: value[1]}))}
       onSubmit={onSubmit}
       onRemove={setShowModal ? () => setShowModal(true) : undefined}
+      disabled={jmeterFile.disabled}
+      planExecutedBefore={jmeterFile.planExecutedBefore}
+      {...{toggleDisabled}}
+      fileId={jmeterFile.id}
     />)}
 
     {isFileUploaded(jmeterFile) && (

--- a/hailstorm-web-client/src/JMeterConfiguration/JMeterFileMessage.tsx
+++ b/hailstorm-web-client/src/JMeterConfiguration/JMeterFileMessage.tsx
@@ -12,7 +12,6 @@ export function JMeterFileMessage({
   setUploadAborted: React.Dispatch<React.SetStateAction<boolean>>;
   disableAbort: boolean;
 }) {
-  console.debug(file);
   let notification: JSX.Element | null = null;
   if (isUploadInProgress(file)) {
     notification = notifyUploadInProgress(file, disableAbort, setUploadAborted);

--- a/hailstorm-web-client/src/JMeterConfiguration/JMeterPropertiesMap.test.tsx
+++ b/hailstorm-web-client/src/JMeterConfiguration/JMeterPropertiesMap.test.tsx
@@ -1,0 +1,30 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import { PropertiesForm } from './JMeterPropertiesMap';
+
+describe('<JMeterPropertiesMap />', () => {
+
+  it('should change properties in form', () => {
+    const {getByTestId, rerender} = render(<PropertiesForm
+      onDisable={jest.fn()}
+      onRemove={jest.fn()}
+      onSubmit={jest.fn()}
+      properties={[{key: "foo", value: "10"}]}
+      fileId={1}
+    />)
+
+    const fooElement = getByTestId("foo");
+    expect(fooElement.getAttribute("value")).toBe("10");
+
+    rerender(<PropertiesForm
+      onDisable={jest.fn()}
+      onRemove={jest.fn()}
+      onSubmit={jest.fn()}
+      properties={[{key: "bar", value: "20"}]}
+      fileId={1}
+    />);
+
+    const barElement = getByTestId("bar");
+    expect(barElement.getAttribute("value")).toBe("20");
+  });
+});

--- a/hailstorm-web-client/src/JMeterConfiguration/StepContent.tsx
+++ b/hailstorm-web-client/src/JMeterConfiguration/StepContent.tsx
@@ -4,7 +4,14 @@ import { JMeterPlanList } from '../JMeterPlanList';
 import styles from '../NewProjectWizard/NewProjectWizard.module.scss';
 import { SelectJMeterFileAction } from './actions';
 import { ActiveFileDetail } from './ActiveFileDetail';
-export function StepContent({ dispatch, state, setShowModal, setUploadAborted, disableAbort }: {
+
+export function StepContent({
+  dispatch,
+  state,
+  setShowModal,
+  setUploadAborted,
+  disableAbort
+}: {
   dispatch: React.Dispatch<any>;
   state: NewProjectWizardState;
   setShowModal: React.Dispatch<React.SetStateAction<boolean>>;
@@ -13,7 +20,12 @@ export function StepContent({ dispatch, state, setShowModal, setUploadAborted, d
 }) {
   return (<div className={`columns ${styles.stepContent}`}>
     <div className="column is-two-fifths">
-      <JMeterPlanList onSelect={(file) => dispatch(new SelectJMeterFileAction(file))} jmeter={state.activeProject!.jmeter} activeFile={state.wizardState!.activeJMeterFile} />
+      <JMeterPlanList
+        onSelect={(file) => dispatch(new SelectJMeterFileAction(file))}
+        jmeter={state.activeProject!.jmeter}
+        activeFile={state.wizardState!.activeJMeterFile}
+        showDisabled={true}
+      />
     </div>
 
     <div className="column is-three-fifths">

--- a/hailstorm-web-client/src/JMeterConfiguration/actions.ts
+++ b/hailstorm-web-client/src/JMeterConfiguration/actions.ts
@@ -12,6 +12,8 @@ export enum JMeterConfigurationActionTypes {
   SelectJMeterFile = '[JMeterConfiguration] SelectJMeterFile',
   RemoveJMeterFile = '[JMeterConfiguration] RemoveJMeterFile',
   FileRemoveInProgress = '[JMeterConfiguration] FileRemoveInProgress',
+  DisableJMeterFile = '[JMeterConfiguration] DisableJMeterFile',
+  EnableJMeterFile = '[JMeterConfiguration] EnableJMeterFile'
 }
 
 export class SetDefaultJMeterVersionAction implements Action {
@@ -59,6 +61,16 @@ export class FileRemoveInProgressAction implements Action {
   constructor(public payload: string) {}
 }
 
+export class DisableJMeterFileAction implements Action {
+  readonly type = JMeterConfigurationActionTypes.DisableJMeterFile;
+  constructor(public payload: number) {}
+}
+
+export class EnableJMeterFileAction implements Action {
+  readonly type = JMeterConfigurationActionTypes.EnableJMeterFile;
+  constructor(public payload: number) {}
+}
+
 export type JMeterConfigurationActions =
   | SetDefaultJMeterVersionAction
   | SetJMeterConfigurationAction
@@ -68,4 +80,6 @@ export type JMeterConfigurationActions =
   | MergeJMeterFileAction
   | SelectJMeterFileAction
   | RemoveJMeterFileAction
-  | FileRemoveInProgressAction;
+  | FileRemoveInProgressAction
+  | DisableJMeterFileAction
+  | EnableJMeterFileAction;

--- a/hailstorm-web-client/src/JMeterPlanList/JMeterPlanList.test.tsx
+++ b/hailstorm-web-client/src/JMeterPlanList/JMeterPlanList.test.tsx
@@ -68,4 +68,38 @@ describe('<JMeterPlanList />', () => {
     const wrapper = shallow(<JMeterPlanList jmeter={{files: []}} disableEdit={true} showEdit={true} />);
     expect(wrapper.find('.button')).toBeDisabled();
   });
+
+  describe('when a plan is disabled', () => {
+    it('should show disabled tag in the list', () => {
+      const component = mount(
+        <JMeterPlanList
+          jmeter={{files: [
+            {id: 100, name: 'a.jmx', properties: new Map([["foo", "10"]]), disabled: true},
+            {id: 99, name: 'a.csv', dataFile: true}
+          ]}}
+          onSelect={jest.fn()}
+          activeFile={{id: 99, name: 'a.csv', dataFile: true}}
+          showDisabled={true}
+        />
+      );
+
+      const blocks = component.find('a').findWhere((wrapper) => wrapper.hasClass('panel-block'));
+      expect(blocks.at(0)).toContainExactlyOneMatchingElement('span.tag');
+    });
+
+    it('should not show disabled plans by default', () => {
+      const component = mount(
+        <JMeterPlanList
+          jmeter={{files: [
+            {id: 100, name: 'a.jmx', properties: new Map([["foo", "10"]]), disabled: true},
+            {id: 110, name: 'b.jmx', properties: new Map([["foo", "10"]])},
+          ]}}
+          onSelect={jest.fn()}
+          activeFile={{id: 100, name: 'a.jmx', properties: new Map([["foo", "10"]])}}
+        />
+      );
+
+      expect(component).toContainMatchingElements(1, 'a');
+    });
+  });
 });

--- a/hailstorm-web-client/src/JMeterPlanList/JMeterPlanList.tsx
+++ b/hailstorm-web-client/src/JMeterPlanList/JMeterPlanList.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { JMeter, JMeterFile } from '../domain';
 import { EmptyPanel } from '../EmptyPanel';
+import styles from '../NewProjectWizard/NewProjectWizard.module.scss';
 
 export interface JMeterPlanListProps {
   showEdit?: boolean;
@@ -9,6 +10,7 @@ export interface JMeterPlanListProps {
   activeFile?: JMeterFile;
   disableEdit?: boolean;
   onEdit?: () => void;
+  showDisabled?: boolean;
 }
 
 export const JMeterPlanList: React.FC<JMeterPlanListProps> = ({
@@ -17,8 +19,14 @@ export const JMeterPlanList: React.FC<JMeterPlanListProps> = ({
   onSelect,
   activeFile,
   disableEdit,
-  onEdit
+  onEdit,
+  showDisabled
 }) => {
+  let fileList: JMeterFile[] = [];
+  if (jmeter) {
+    fileList = showDisabled ? jmeter.files : jmeter.files.filter((v) => !v.disabled);
+  }
+
   return (
     <div className="panel" data-testid="JMeter Plans">
       <div className="panel-heading">
@@ -39,17 +47,17 @@ export const JMeterPlanList: React.FC<JMeterPlanListProps> = ({
           </div>
         </div>
       </div>
-      {jmeter && jmeter.files.length > 0 ? renderPlanList(jmeter, onSelect, activeFile) : renderEmptyList()}
+      {fileList.length > 0 ? renderPlanList(fileList, onSelect, activeFile) : renderEmptyList()}
     </div>
   );
 }
 
 function renderPlanList(
-  jmeter: JMeter,
+  fileList: JMeterFile[],
   handleSelect?: (file: JMeterFile) => void,
   activeFile?: JMeterFile
 ): React.ReactNode {
-  return jmeter.files.map((plan) => {
+  return fileList.map((plan) => {
     const item = (
       <>
         <span className="panel-icon">
@@ -60,6 +68,7 @@ function renderPlanList(
         )}
         </span>
         {plan.name}
+        {plan.disabled && (<span className={`tag is-dark ${styles.titleLabel}`}>disabled</span>)}
       </>
     );
 

--- a/hailstorm-web-client/src/NewProjectWizard/NewProjectWizard.module.scss
+++ b/hailstorm-web-client/src/NewProjectWizard/NewProjectWizard.module.scss
@@ -90,3 +90,11 @@
 .dangerSettings {
   margin-top: 20rem;
 }
+
+.disabledContent {
+  background-color: $white-ter;
+}
+
+.titleLabel {
+  margin-left: 1rem;
+}

--- a/hailstorm-web-client/src/NewProjectWizard/SummaryView.test.tsx
+++ b/hailstorm-web-client/src/NewProjectWizard/SummaryView.test.tsx
@@ -32,6 +32,14 @@ describe('<SummaryView />', () => {
             id: 5,
             name: 'testdroid_accounts.csv',
             dataFile: true
+          },
+          {
+            name: 'a.jmx',
+            id: 6,
+            properties: new Map([
+              ["NumThreads", "10"]
+            ]),
+            disabled: true
           }
         ]
       },
@@ -135,5 +143,15 @@ describe('<SummaryView />', () => {
     component.find('StepFooter button').simulate('click');
     expect(dispatch).toBeCalled();
     expect(dispatch.mock.calls[0][0]).toBeInstanceOf(ReviewCompletedAction);
+  });
+
+  it('should not show disabled test plans', () => {
+    const component = mount(
+      <AppStateProviderWithProps {...{appState, dispatch: jest.fn()}}>
+        <SummaryView />
+      </AppStateProviderWithProps>
+    );
+
+    expect(component.text()).not.toMatch(/a\.jmx/);
   });
 });

--- a/hailstorm-web-client/src/NewProjectWizard/SummaryView.tsx
+++ b/hailstorm-web-client/src/NewProjectWizard/SummaryView.tsx
@@ -92,7 +92,7 @@ function JMeterSection({
     <div className="card">
       <div className="card-content">
         <div className="content">
-        {jmeter.files.map((jmeterFile) => (
+        {jmeter.files.filter((v) => !v.disabled).map((jmeterFile) => (
           <JMeterFileDetail {...{jmeterFile}} key={jmeterFile.id} headerTitle={jmeterFile.name} />
         ))}
         </div>

--- a/hailstorm-web-client/src/domain.ts
+++ b/hailstorm-web-client/src/domain.ts
@@ -75,6 +75,7 @@ export interface JMeterFile {
   dataFile?: boolean;
   disabled?: boolean;
   path?: string;
+  planExecutedBefore?: boolean;
 }
 
 export interface ValidationNotice {


### PR DESCRIPTION
# Description

As a test plan is uploaded, it can be removed. When it is saved, it can additionally be disabled. When it is executed successfully in a load test, it can only be disabled, not removed.

# Linked Issues

- fixes #132 

# Checklist

- [x] If a new feature is being added, I have added a corresponding post to ``docs/``.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have made corresponding changes to the wiki where applicable.
